### PR TITLE
Browserify API broken

### DIFF
--- a/plugin.coffee
+++ b/plugin.coffee
@@ -1,35 +1,42 @@
-
 browserify = require 'browserify'
-path = require 'path'
+path       = require 'path'
+coffeeify  = require 'coffeeify'
+
+# -----
 
 stripExtension = (filename) ->
   filename.replace /(.+)\.[^.]+$/, '$1'
 
+# -----
+
 module.exports = (wintersmith, callback) ->
-
   class BrowserifyPlugin extends wintersmith.ContentPlugin
-
     constructor: (@_filename, @_base) ->
 
     getFilename: ->
       "#{ stripExtension @_filename }.js"
 
     render: (locals, contents, templates, callback) ->
-      bundle = browserify
-        cache: false
-        watch: false
+      # Set up browserify/transform stream
+      brows = browserify path.join(@_base, @_filename)
+      brows.transform coffeeify
 
-      bundle.addListener 'syntaxError', (error) ->
-        callback error
-        # unset callback so we don't call it twice
-        callback = null
+      s = brows.bundle()
 
-      # wrap in try catch since coffeescript parse errors will throw..
-      try
-        bundle.addEntry path.join(@_base, @_filename)
-        callback? null, new Buffer bundle.bundle()
-      catch error
-        callback? error
+      # Set up buffer
+      dbuf = []
+      dbuf_fin =->
+        callback null, new Buffer (dbuf.join "")
+
+      # Catch events
+      s.on 'data', (d)->
+          dbuf.push d
+
+      s.on 'error', (er) ->
+          callback er
+
+      s.on 'end',   dbuf_fin
+      s.on 'close', dbuf_fin
 
   BrowserifyPlugin.fromFile = (filename, base, callback) ->
     callback null, new BrowserifyPlugin filename, base


### PR DESCRIPTION
Hi,
there have been vast changes in the Browserify API, e.g. look at:

_exports in line 6/index.js_
https://github.com/substack/node-browserify/commit/04cc3b6a44610df8401e5d1c89d26ff29cd8420e#index.js

I have updated this plugin so It works again on my machine,
especially fixing these Issues:
- Browserify now is not initialized with options but with files
- A buffer can not be created from a stream

_This is my first time working with node.js streams so could you please have a look if used the api badly. Also this definitly should by tested by someone else again._
