### PR TITLE
add fileGlob option for file matching on register

### DIFF
--- a/plugin.coffee
+++ b/plugin.coffee
@@ -18,6 +18,12 @@ module.exports = (env, callback) ->
   options.ignore ?= []
   options.extensions ?= ['.js', '.coffee']
 
+  # fileGlob for matching - default to provided extensions
+  exts = options.extensions
+    .map (ext) -> ext[1..]
+    .join '|'
+  options.fileGlob ?= "**/*.*(#{ exts })"
+
   staticCache = {}
 
   # watchify speeds up builds by only rebundling files that have changed
@@ -100,9 +106,6 @@ module.exports = (env, callback) ->
   BrowserifyPlugin.fromFile = (filepath, callback) ->
     callback null, new BrowserifyPlugin filepath
 
-  exts = options.extensions
-    .map (ext) -> ext[1..]
-    .join '|'
+  env.registerContentPlugin 'scripts', options.fileGlob, BrowserifyPlugin
 
-  env.registerContentPlugin 'scripts', "**/*.*(#{ exts })", BrowserifyPlugin
   callback()


### PR DESCRIPTION
- Add check for fileGlob in configuration options for the plugin
- Fall back to glob built from options.extensions "**/*.*(js|coffee)"